### PR TITLE
feat: Add support for security_patch.txt

### DIFF
--- a/service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java
+++ b/service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java
@@ -561,8 +561,8 @@ public final class CertHack {
             var AosPatchLevel = new ASN1Integer(UtilKt.getPatchLevel());
 
             var AapplicationID = createApplicationId(uid);
-            var AbootPatchlevel = new ASN1Integer(UtilKt.getPatchLevelLong());
-            var AvendorPatchLevel = new ASN1Integer(UtilKt.getPatchLevelLong());
+            var AbootPatchlevel = new ASN1Integer(UtilKt.getBootPatchLevelLong());
+            var AvendorPatchLevel = new ASN1Integer(UtilKt.getVendorPatchLevelLong());
 
             var AcreationDateTime = new ASN1Integer(System.currentTimeMillis());
             var Aorigin = new ASN1Integer(0);


### PR DESCRIPTION
- Mimics official TrickyStore syntax.
- Use devconfig.toml as fallback if security_patch.txt is not detected.
- If both security_patch.txt and devconfig.toml are not present then device props will be used.
- Requires reboot to apply affects.