### PR TITLE
Add support for ARMv7 devices

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ val description by extra("A trick of keystore")
 val verName by extra("v3.16")
 val verCode by extra(gitCommitCount)
 val commitHash by extra(gitCommitHash)
-val abiList by extra(listOf("arm64-v8a", "x86_64"))
+val abiList by extra(listOf("arm64-v8a", "armeabi-v7a", "x86_64"))
 
 val androidMinSdkVersion by extra(29)
 val androidTargetSdkVersion by extra(35)

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -71,15 +71,20 @@ extract "$ZIPFILE" 'daemon'          "$MODPATH"
 chmod 755 "$MODPATH/daemon"
 
 
-if [ "$ARCH" = "x64" ]; then
-  ui_print "- Extracting x64 libraries"
-  extract "$ZIPFILE" "lib/x86_64/lib$SONAME.so" "$MODPATH" true
-  extract "$ZIPFILE" "lib/x86_64/libinject.so" "$MODPATH" true
-else
-  ui_print "- Extracting arm64 libraries"
-  extract "$ZIPFILE" "lib/arm64-v8a/lib$SONAME.so" "$MODPATH" true
-  extract "$ZIPFILE" "lib/arm64-v8a/libinject.so" "$MODPATH" true
-fi
+case $ARCH in
+  "x64")
+    ui_print "- Extracting x64 libraries"
+    extract "$ZIPFILE" "lib/x86_64/lib$SONAME.so" "$MODPATH" true
+    extract "$ZIPFILE" "lib/x86_64/libinject.so" "$MODPATH" true ;;
+  "arm64")
+    ui_print "- Extracting arm64 libraries"
+    extract "$ZIPFILE" "lib/arm64-v8a/lib$SONAME.so" "$MODPATH" true
+    extract "$ZIPFILE" "lib/arm64-v8a/libinject.so" "$MODPATH" true ;;
+  "arm")
+    ui_print "- Extracting arm libraries"
+    extract "$ZIPFILE" "lib/armeabi-v7a/lib$SONAME.so" "$MODPATH" true
+    extract "$ZIPFILE" "lib/armeabi-v7a/libinject.so" "$MODPATH" true ;;
+esac
 
 mv "$MODPATH/libinject.so" "$MODPATH/inject"
 chmod 755 "$MODPATH/inject"


### PR DESCRIPTION
Adds the  "armeabi-v7a" architecture in `build.gradle.kts` and fixes the `customize.sh` script to take armv7 targets into account.